### PR TITLE
Update btn.jsx

### DIFF
--- a/client/src/Components/btn.jsx
+++ b/client/src/Components/btn.jsx
@@ -1,94 +1,106 @@
-import React from 'react';
+// BtnEnhanced.tsx
+// ----------------------------------------------------------------------------------
+// A11y‑friendly, variant‑driven React (Next.js‑ready) button built with Tailwind CSS.
+// ----------------------------------------------------------------------------------
+// • Two built‑in variants (neon & cyber) + ghost fallback
+// • Size variants (sm | md | lg)
+// • Ref‑forwarding, ARIA disabled semantics, loading spinner
+// • Optional animated glow edge for neon variant
+// • Uses class‑variance‑authority for tidy variant handling
+// • Leverages lucide‑react icons, but accepts any ReactNode icon prop
+//
+// ⬇️ Drop `cn` helper in @/lib/utils (clsx + tailwind‑merge) if you don’t have one.
+// ----------------------------------------------------------------------------------
 
-const Btn = ({ text, handle, style = true, dull = false, disabled = false, className = '', icon = null }) => {
-  // Base classes that apply to all buttons
-  const baseClasses = `relative px-6 py-3 rounded-lg whitespace-nowrap tracking-wider overflow-hidden transition-all duration-300 font-medium ${className}`;
-  
-  // Style 1: Glowing Neon Button
-  if (style) {
+"use client";
+
+import * as React from "react";
+import { cva, VariantProps } from "class-variance-authority";
+import { Loader2, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Variants
+   ────────────────────────────────────────────────────────────────────────── */
+const buttonVariants = cva(
+  "relative inline-flex items-center justify-center gap-2 rounded-lg overflow-hidden font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 select-none",
+  {
+    variants: {
+      variant: {
+        neon:
+          "px-6 py-3 text-white bg-gradient-to-r from-pink-600 to-purple-600 shadow-[0_0_12px_rgba(237,0,255,0.4)] hover:shadow-[0_0_20px_rgba(237,0,255,0.7)]",
+        cyber:
+          "px-6 py-2 font-mono border-2 border-pink-400 bg-neutral-900 text-pink-400 hover:border-pink-200 hover:text-pink-200 shadow-[0_0_15px_rgba(236,72,153,0.5)] hover:shadow-[0_0_20px_rgba(236,72,153,0.8)]",
+        ghost: "px-4 py-2 border bg-transparent hover:bg-muted",
+      },
+      size: {
+        sm: "text-sm",
+        md: "text-base",
+        lg: "text-lg",
+      },
+    },
+    defaultVariants: {
+      variant: "neon",
+      size: "md",
+    },
+  }
+);
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Props
+   ────────────────────────────────────────────────────────────────────────── */
+export interface BtnProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  icon?: React.ReactNode;
+  loading?: boolean;
+  glow?: boolean; // adds animated edge glow on neon variant
+}
+
+/* ──────────────────────────────────────────────────────────────────────────
+   Component
+   ────────────────────────────────────────────────────────────────────────── */
+export const Btn = React.forwardRef<HTMLButtonElement, BtnProps>(
+  (
+    {
+      className,
+      children,
+      icon,
+      loading = false,
+      variant,
+      size,
+      glow = true,
+      ...props
+    },
+    ref
+  ) => {
     return (
-      <button 
-        onClick={handle}
-        disabled={disabled || dull}
-        className={`${baseClasses} group ${dull ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer'}`}
+      <button
+        ref={ref}
+        aria-disabled={props.disabled || loading}
+        data-variant={variant}
+        data-size={size}
+        className={cn(buttonVariants({ variant, size }), className)}
+        {...props}
       >
-        {/* Background gradient with reduced opacity when dull */}
-        <span className={`absolute inset-0 bg-gradient-to-r from-pink-600 to-purple-600 rounded-lg transition-opacity ${
-          dull ? 'opacity-30' : 'opacity-75 group-hover:opacity-100'
-        }`}></span>
-        
-        {/* Button edge highlights - hidden when dull */}
-        {!dull && (
-          <>
-            <span className="absolute top-0 left-0 w-full h-0.5 bg-white/50"></span>
-            <span className="absolute bottom-0 left-0 w-full h-0.5 bg-white/50"></span>
-          </>
+        {/* Animated glow background (neon) */}
+        {glow && variant === "neon" && (
+          <span
+            aria-hidden
+            className="absolute inset-0 rounded-lg bg-gradient-to-r from-pink-600 to-purple-600 opacity-75 blur-md transition-opacity group-hover:opacity-100"
+          />
         )}
-        
-        {/* Main button content */}
-        <span className="relative z-10 flex items-center justify-center gap-2 text-white">
-          {icon && <span className="text-lg">{icon}</span>}
-          {text}
-          {!dull && <span className="group-hover:translate-x-1 transition-transform">→</span>}
+
+        {/* MAIN CONTENT */}
+        <span className="relative z-10 flex items-center gap-2">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : icon}
+          {children}
+          {!loading && variant === "neon" && (
+            <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+          )}
         </span>
-        
-        {/* Hover animation - disabled when dull */}
-        {!dull && (
-          <span className="absolute inset-0 border-2 border-white/20 rounded-lg group-hover:border-white/40"></span>
-        )}
       </button>
     );
   }
-
-  // Style 2: Cyberpunk Button
-  return (
-    <button 
-      onClick={handle}
-      disabled={disabled || dull}
-      className={`${baseClasses} font-mono font-bold border-2 ${
-        dull 
-          ? 'bg-gray-800 text-gray-500 border-gray-600 cursor-not-allowed'
-          : ' bg-neutral-800 text-pink-400 border-pink-400 hover:border-pink-200 hover:text-pink-200 cursor-pointer shadow-[0_0_15px_rgba(236,72,153,0.5)] hover:shadow-[0_0_20px_rgba(236,72,153,0.8)]'
-      }`}
-    >
-      {/* Pixel corners - change color when dull */}
-      <span className={`absolute top-0 left-0 w-3 h-3 border-t-2 border-l-2 ${
-        dull ? 'border-gray-600' : 'border-pink-400'
-      }`}></span>
-      <span className={`absolute top-0 right-0 w-3 h-3 border-t-2 border-r-2 ${
-        dull ? 'border-gray-600' : 'border-pink-400'
-      }`}></span>
-      <span className={`absolute bottom-0 left-0 w-3 h-3 border-b-2 border-l-2 ${
-        dull ? 'border-gray-600' : 'border-pink-400'
-      }`}></span>
-      <span className={`absolute bottom-0 right-0 w-3 h-3 border-b-2 border-r-2 ${
-        dull ? 'border-gray-600' : 'border-pink-400'
-      }`}></span>
-      
-      {/* Text with scanline effect - disabled when dull */}
-      <span className="relative">
-        <span className={`block h-6 overflow-hidden ${
-          dull ? '' : 'hover:text-white'
-        }`}>
-          <span className={`block ${
-            dull ? '' : 'animate-[scanline_8s_linear_infinite]'
-          }`}>
-            {text.split('').map((char, i) => (
-              <span 
-                key={i} 
-                className={`inline-block min-w-[0.5em] ${
-                  dull ? '' : 'hover:scale-110 transition-transform duration-100'
-                }`}
-                style={dull ? {} : { animationDelay: `${i * 0.05}s` }}
-              >
-                {char}
-              </span>
-            ))}
-          </span>
-        </span>
-      </span>
-    </button>
-  );
-};
-
-export default Btn;
+);
+Btn.displayName = "Btn";


### PR DESCRIPTION
I converted it into a variant‑driven, a11y‑friendly TypeScript React component with:

Variant system (neon | cyber | ghost) & size props via class‑variance‑authority for clean, scalable styling

Forwarded ref, aria‑disabled, and loading spinner for accessibility and UX polish

Optional animated neon glow and built‑in right‑arrow indicator

Tailwind‑merge‑aware cn() helper so custom classes don’t clash

Lucide‑react icons but still accepts any icon node

Self‑documenting prop types and sensible defaults

Drop it into any Next.js/Tailwind project—only external needs are class-variance-authority, lucide-react, and your cn util. Let me know if you’d like additional variants or motion effects!
